### PR TITLE
feat: add configuration property to enable/disable autoconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ drednote.telegram.name=<Your bot name>
 drednote.telegram.token=<Your bot token>
 ```
 
+Or disable the autoconfiguration with
+```properties
+drednote.telegram.enabled=false
+```
+
 Create your main controller
 
 ```java

--- a/src/main/java/io/github/drednote/telegram/TelegramAutoConfiguration.java
+++ b/src/main/java/io/github/drednote/telegram/TelegramAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
@@ -31,10 +32,12 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
  * Autoconfiguration class for configuring various aspects of a Telegram bot application.
  *
  * <p>This class provides automatic configuration for different components and features of a
- * Telegram bot application, including bot configuration, message source configuration, and more. It
- * utilizes properties defined in the application's configuration to customize the behavior of the
+ * Telegram bot application, including bot configuration, message source configuration, and more.
+ * You can disable the Autoconfiguration with the property {@code dreadnote.telegram.enabled}.
+ * It utilizes properties defined in the application's configuration to customize the behavior of the
  * bot.
  */
+@ConditionalOnProperty(prefix = "drednote.telegram", name = "enabled" )
 @ImportAutoConfiguration({
     SessionAutoConfiguration.class, UpdateHandlerAutoConfiguration.class,
     ExceptionHandlerAutoConfiguration.class, DataSourceAutoConfiguration.class,
@@ -70,6 +73,7 @@ public class TelegramAutoConfiguration {
          */
         @Bean
         @ConditionalOnMissingBean(TelegramBot.class)
+        @ConditionalOnProperty(name = "drednote.telegram.token")
         public TelegramBot telegramLongPollingBot(
             TelegramProperties properties, Collection<UpdateHandler> updateHandlers,
             ObjectMapper objectMapper, ExceptionHandler exceptionHandler,

--- a/src/main/java/io/github/drednote/telegram/TelegramProperties.java
+++ b/src/main/java/io/github/drednote/telegram/TelegramProperties.java
@@ -21,7 +21,10 @@ import org.springframework.lang.Nullable;
 @Getter
 @Setter
 public class TelegramProperties {
-
+  /**
+   * Enable the bot Default: true
+   */
+  private boolean enabled = true;
   /**
    * The name of a bot. Example: TheBestBot.
    * <p>


### PR DESCRIPTION
Added @ConditionalOnProperty annotation to the autoconfiguration class to ensure it is 
loaded only when `dreadnote.telegram.name` and `dreadnote.telegram.token` properties are set. 
This change prevents the error:

Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate 
[org.telegram.telegrambots.meta.generics.TelegramClient]: Factory method 'absSender' 
threw exception with message: null