### PR TITLE
Fix force setting of the message parsing method

### DIFF
--- a/src/main/java/io/github/drednote/telegram/core/DefaultTelegramBot.java
+++ b/src/main/java/io/github/drednote/telegram/core/DefaultTelegramBot.java
@@ -9,7 +9,6 @@ import io.github.drednote.telegram.filter.post.ConclusivePostUpdateFilter;
 import io.github.drednote.telegram.filter.post.PostUpdateFilter;
 import io.github.drednote.telegram.filter.pre.PreUpdateFilter;
 import io.github.drednote.telegram.handler.UpdateHandler;
-import io.github.drednote.telegram.handler.UpdateHandlerProperties;
 import io.github.drednote.telegram.response.AbstractTelegramResponse;
 import io.github.drednote.telegram.response.SimpleMessageTelegramResponse;
 import io.github.drednote.telegram.response.TelegramResponse;
@@ -237,7 +236,7 @@ public class DefaultTelegramBot implements TelegramBot {
                 simpleMessageTelegramResponse.setMessageSource(messageSource);
             }
             if (response instanceof AbstractTelegramResponse abstractTelegramResponse) {
-                if (abstractTelegramResponse.getParseMode() == UpdateHandlerProperties.ParseMode.NO) {
+                if (abstractTelegramResponse.getParseMode() == null) {
                     abstractTelegramResponse.setParseMode(
                             telegramProperties.getUpdateHandler().getParseMode()
                     );

--- a/src/main/java/io/github/drednote/telegram/core/DefaultTelegramBot.java
+++ b/src/main/java/io/github/drednote/telegram/core/DefaultTelegramBot.java
@@ -9,6 +9,7 @@ import io.github.drednote.telegram.filter.post.ConclusivePostUpdateFilter;
 import io.github.drednote.telegram.filter.post.PostUpdateFilter;
 import io.github.drednote.telegram.filter.pre.PreUpdateFilter;
 import io.github.drednote.telegram.handler.UpdateHandler;
+import io.github.drednote.telegram.handler.UpdateHandlerProperties;
 import io.github.drednote.telegram.response.AbstractTelegramResponse;
 import io.github.drednote.telegram.response.SimpleMessageTelegramResponse;
 import io.github.drednote.telegram.response.TelegramResponse;
@@ -236,8 +237,11 @@ public class DefaultTelegramBot implements TelegramBot {
                 simpleMessageTelegramResponse.setMessageSource(messageSource);
             }
             if (response instanceof AbstractTelegramResponse abstractTelegramResponse) {
-                abstractTelegramResponse.setParseMode(
-                    telegramProperties.getUpdateHandler().getParseMode());
+                if (abstractTelegramResponse.getParseMode() == UpdateHandlerProperties.ParseMode.NO) {
+                    abstractTelegramResponse.setParseMode(
+                            telegramProperties.getUpdateHandler().getParseMode()
+                    );
+                }
             }
             response.process(request);
         }

--- a/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
+++ b/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
@@ -2,6 +2,9 @@ package io.github.drednote.telegram.response;
 
 import io.github.drednote.telegram.core.request.UpdateRequest;
 import io.github.drednote.telegram.handler.UpdateHandlerProperties.ParseMode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.lang.Nullable;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -14,7 +17,10 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
  */
 public abstract class AbstractTelegramResponse implements TelegramResponse {
 
-    protected ParseMode parseMode = ParseMode.NO;
+    @Getter
+    @Setter
+    @Nullable
+    protected ParseMode parseMode = null;
 
     /**
      * Sends a text message to the specified chat using the provided string
@@ -29,15 +35,8 @@ public abstract class AbstractTelegramResponse implements TelegramResponse {
         TelegramClient absSender = request.getAbsSender();
         Long chatId = request.getChatId();
         SendMessage sendMessage = new SendMessage(chatId.toString(), string);
+        if (parseMode == null) parseMode = ParseMode.NO;
         sendMessage.setParseMode(parseMode.getValue());
         return absSender.execute(sendMessage);
-    }
-
-    public void setParseMode(ParseMode parseMode) {
-        this.parseMode = parseMode;
-    }
-
-    public ParseMode getParseMode() {
-        return parseMode;
     }
 }

--- a/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
+++ b/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
@@ -36,4 +36,8 @@ public abstract class AbstractTelegramResponse implements TelegramResponse {
     public void setParseMode(ParseMode parseMode) {
         this.parseMode = parseMode;
     }
+
+    public ParseMode getParseMode() {
+        return parseMode;
+    }
 }

--- a/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
+++ b/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
@@ -2,8 +2,6 @@ package io.github.drednote.telegram.response;
 
 import io.github.drednote.telegram.core.request.UpdateRequest;
 import io.github.drednote.telegram.handler.UpdateHandlerProperties.ParseMode;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.lang.Nullable;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
@@ -17,8 +15,6 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
  */
 public abstract class AbstractTelegramResponse implements TelegramResponse {
 
-    @Getter
-    @Setter
     @Nullable
     protected ParseMode parseMode = null;
 
@@ -38,5 +34,14 @@ public abstract class AbstractTelegramResponse implements TelegramResponse {
         if (parseMode == null) parseMode = ParseMode.NO;
         sendMessage.setParseMode(parseMode.getValue());
         return absSender.execute(sendMessage);
+    }
+
+    public void setParseMode(ParseMode parseMode) {
+        this.parseMode = parseMode;
+    }
+
+    @Nullable
+    public ParseMode getParseMode() {
+        return parseMode;
     }
 }

--- a/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
+++ b/src/main/java/io/github/drednote/telegram/response/AbstractTelegramResponse.java
@@ -31,8 +31,9 @@ public abstract class AbstractTelegramResponse implements TelegramResponse {
         TelegramClient absSender = request.getAbsSender();
         Long chatId = request.getChatId();
         SendMessage sendMessage = new SendMessage(chatId.toString(), string);
-        if (parseMode == null) parseMode = ParseMode.NO;
-        sendMessage.setParseMode(parseMode.getValue());
+        if (parseMode != null) {
+            sendMessage.setParseMode(parseMode.getValue());
+        }
         return absSender.execute(sendMessage);
     }
 


### PR DESCRIPTION
Make force setting of the message parsing method only if AbstractTelegramResponse parsing method is "NO".

Previously, if you set setParseMode({value}) for GenericTelegramResponse, set {value} was ignored