### PR TITLE
fix: scenario and request context

### DIFF
--- a/src/main/java/io/github/drednote/telegram/core/UpdateRequestContext.java
+++ b/src/main/java/io/github/drednote/telegram/core/UpdateRequestContext.java
@@ -19,8 +19,8 @@ import org.springframework.lang.NonNull;
  * Utility class for managing Telegram bot update request contexts and associated beans.
  *
  * <p>This abstract class provides a set of static methods to manage and access
- * Telegram bot update request contexts along with their associated beans. It uses thread-local
- * storage to store the current update request context for each thread processing bot requests.
+ * Telegram bot update request contexts along with their associated beans. It uses thread-local storage to store the
+ * current update request context for each thread processing bot requests.
  *
  * <p>The class supports storing and retrieving the {@link UpdateRequest}. It also provides
  * methods for safely removing the update request and optionally destroying associated beans.
@@ -29,9 +29,8 @@ import org.springframework.lang.NonNull;
  * to create beans with Telegram request scope. See {@link TelegramScope}.
  *
  * <p>You should not use this class directly. The only one purpose to use it if you creating
- * sub-threads within the main thread, you will need to manually bind the
- * {@code UpdateRequest} to the new thread by calling
- * {@link #saveRequest(UpdateRequest)}.
+ * sub-threads within the main thread, you will need to manually bind the {@code UpdateRequest} to the new thread by
+ * calling {@link #saveRequest(UpdateRequest)}.
  * <b>If you do this, do not forget to call {@link #removeRequest(boolean)} with parameter {@code
  * false} on every sub-thread when it is finished</b>
  *
@@ -42,88 +41,101 @@ import org.springframework.lang.NonNull;
  */
 public abstract class UpdateRequestContext implements ApplicationContextAware {
 
-  /**
-   * key = thread id
-   */
-  private static final Map<Long, UpdateRequest> requests = new ConcurrentHashMap<>();
-  /**
-   * key = update id
-   */
-  static final Map<Integer, List<String>> beanNames = new ConcurrentHashMap<>();
-  private static ConfigurableBeanFactory factory;
+    private static final ThreadLocal<UpdateRequest> inheritableRequestsHolder = new InheritableThreadLocal<>();
+    private static final ThreadLocal<UpdateRequest> requestsHolder = new ThreadLocal<>();
+    /**
+     * key = update id
+     */
+    static final Map<Integer, List<String>> beanNames = new ConcurrentHashMap<>();
+    private static ConfigurableBeanFactory factory;
 
-  UpdateRequestContext() {
-  }
+    private static boolean inheritable = false;
 
-  /**
-   * Saves the provided Telegram update request in the current thread's context.
-   *
-   * <p><b>Do not call this method manually if you not creating sub-threads</b>
-   *
-   * @param request The Telegram update request to be saved
-   */
-  public static void saveRequest(UpdateRequest request) {
-    Assert.notNull(request, "request");
-    requests.put(Thread.currentThread().getId(), request);
-  }
+    UpdateRequestContext() {
+    }
 
-  /**
-   * Retrieves the Telegram update request from the current thread's context.
-   *
-   * @return The Telegram update request associated with the current thread
-   * @throws IllegalStateException if no update request is found for the current thread
-   */
-  @NonNull
-  static UpdateRequest getRequest() {
-    return Optional.of(Thread.currentThread().getId())
-        .map(requests::get)
-        .orElseThrow(() -> new IllegalStateException("No thread-bound bot request found: " +
-            "Are you referring to request outside of an actual bot request, " +
-            "or processing a request outside of the originally receiving thread? "
-            + "Check the documentation of this class to solve the problem"));
-  }
-
-  /**
-   * Removes the Telegram update request from the current thread's context.
-   *
-   * <p><b>Do not call this method manually if you not creating sub-threads. If you need to remove
-   * request after sub-thread is finished, call with {@code false} parameter</b>
-   *
-   * @param destroyBeans Whether to destroy associated beans
-   */
-  public static void removeRequest(boolean destroyBeans) {
-    if (destroyBeans) {
-      UpdateRequest request = getRequest();
-      synchronized (request) {
-        List<String> names = beanNames.remove(request.getId());
-        if (names != null) {
-          for (String name : names) {
-            factory.destroyScopedBean(name);
-          }
+    /**
+     * Saves the provided Telegram update request in the current thread's context.
+     *
+     * <p><b>Do not call this method manually if you not creating sub-threads</b>
+     *
+     * @param request The Telegram update request to be saved
+     */
+    public static void saveRequest(UpdateRequest request) {
+        Assert.notNull(request, "request");
+        if (inheritable) {
+            inheritableRequestsHolder.set(request);
+        } else {
+            requestsHolder.set(request);
         }
-      }
     }
-    requests.remove(Thread.currentThread().getId());
-  }
 
-  /**
-   * Saves the name of a bean associated with the current update request.
-   *
-   * @param name The name of the bean to be saved
-   */
-  static void saveBeanName(@NonNull String name) {
-    Assert.notEmpty(name, "name");
-
-    UpdateRequest request = getRequest();
-    synchronized (request) {
-      List<String> names = beanNames.computeIfAbsent(request.getId(), key -> new ArrayList<>());
-      names.add(name);
+    /**
+     * Retrieves the Telegram update request from the current thread's context.
+     *
+     * @return The Telegram update request associated with the current thread
+     * @throws IllegalStateException if no update request is found for the current thread
+     */
+    @NonNull
+    static UpdateRequest getRequest() {
+        return Optional.ofNullable(inheritable ? inheritableRequestsHolder.get() : requestsHolder.get())
+            .orElseThrow(() -> new IllegalStateException("No thread-bound bot request found: "
+                                                         + "Are you referring to request outside of an actual bot request, "
+                                                         + "or processing a request outside of the originally receiving thread? "
+                                                         + "Check the documentation of this class to solve the problem"));
     }
-  }
 
-  @Override
-  public void setApplicationContext(@NonNull ApplicationContext applicationContext)
-      throws BeansException {
-    this.factory = ((ConfigurableApplicationContext) applicationContext).getBeanFactory();
-  }
+    /**
+     * Removes the Telegram update request from the current thread's context.
+     *
+     * <p><b>Do not call this method manually if you not creating sub-threads. If you need to remove
+     * request after sub-thread is finished, call with {@code false} parameter</b>
+     *
+     * @param destroyBeans Whether to destroy associated beans
+     */
+    public static void removeRequest(boolean destroyBeans) {
+        if (destroyBeans) {
+            UpdateRequest request = getRequest();
+            synchronized (request) {
+                List<String> names = beanNames.remove(request.getId());
+                if (names != null) {
+                    for (String name : names) {
+                        factory.destroyScopedBean(name);
+                    }
+                }
+            }
+        }
+        inheritableRequestsHolder.remove();
+        requestsHolder.remove();
+    }
+
+    /**
+     * Saves the name of a bean associated with the current update request.
+     *
+     * @param name The name of the bean to be saved
+     */
+    static void saveBeanName(@NonNull String name) {
+        Assert.notEmpty(name, "name");
+
+        UpdateRequest request = getRequest();
+        synchronized (request) {
+            List<String> names = beanNames.computeIfAbsent(request.getId(), key -> new ArrayList<>());
+            names.add(name);
+        }
+    }
+
+    @Override
+    public void setApplicationContext(@NonNull ApplicationContext applicationContext)
+        throws BeansException {
+        this.factory = ((ConfigurableApplicationContext) applicationContext).getBeanFactory();
+    }
+
+    /**
+     * Set inheritance of context.
+     *
+     * @param value true or false
+     */
+    public static void setInheritable(boolean value) {
+        inheritable = value;
+    }
 }

--- a/src/main/java/io/github/drednote/telegram/core/request/ParsedUpdateRequest.java
+++ b/src/main/java/io/github/drednote/telegram/core/request/ParsedUpdateRequest.java
@@ -8,6 +8,7 @@ import io.github.drednote.telegram.handler.scenario.Scenario;
 import io.github.drednote.telegram.response.TelegramResponse;
 import java.io.Serializable;
 import java.util.List;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
@@ -27,6 +28,7 @@ public class ParsedUpdateRequest extends AbstractUpdateRequest {
     }
 
     @Override
+    @NonNull
     public TelegramClient getAbsSender() {
         return telegramClient;
     }
@@ -47,6 +49,7 @@ public class ParsedUpdateRequest extends AbstractUpdateRequest {
     }
 
     @Override
+    @NonNull
     public List<Serializable> getResponseFromTelegram() {
         throw new UnsupportedOperationException("Not supported in this implementation");
     }
@@ -57,6 +60,7 @@ public class ParsedUpdateRequest extends AbstractUpdateRequest {
     }
 
     @Override
+    @NonNull
     public TelegramProperties getProperties() {
         throw new UnsupportedOperationException("Not supported in this implementation");
     }
@@ -67,6 +71,7 @@ public class ParsedUpdateRequest extends AbstractUpdateRequest {
     }
 
     @Override
+    @NonNull
     public ObjectMapper getObjectMapper() {
         throw new UnsupportedOperationException("Not supported in this implementation");
     }

--- a/src/main/java/io/github/drednote/telegram/core/request/UpdateRequest.java
+++ b/src/main/java/io/github/drednote/telegram/core/request/UpdateRequest.java
@@ -30,8 +30,8 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 /**
  * The {@code UpdateRequest} interface represents a request received from
  * <a href="https://core.telegram.org/bots/api">Telegram API</a> as an {@link Update}.
- * Implementations of this interface provide getters and setters to access and modify the various
- * properties of the request.
+ * Implementations of this interface provide getters and setters to access and modify the various properties of the
+ * request.
  *
  * @author Ivan Galushko
  */
@@ -65,6 +65,16 @@ public interface UpdateRequest {
     Long getUserId();
 
     /**
+     * This ID is needed to identify a unique user based on ChatId and UserId. If UserId is null, then will be returned
+     * only to ChatId.
+     *
+     * @return unique user ID
+     */
+    default String getUserAssociatedId() {
+        return getUserId() == null ? getChatId().toString() : getUserId() + "_" + getChatId();
+    }
+
+    /**
      * Returns the type of the request
      *
      * @return the type of the request
@@ -75,11 +85,11 @@ public interface UpdateRequest {
     /**
      * Returns the types of message contained in the request
      * <p>
-     * In case if a type of message cannot correctly be determined, then will be return an empty set
-     * Typically, this shows something went wrong
+     * In case if a type of message cannot correctly be determined, then will be return an empty set Typically, this
+     * shows something went wrong
      *
-     * @return the types of message, or an empty set if the request is not a message or the message
-     * types cannot be determined
+     * @return the types of message, or an empty set if the request is not a message or the message types cannot be
+     * determined
      */
     @NonNull
     Set<MessageType> getMessageTypes();
@@ -87,8 +97,8 @@ public interface UpdateRequest {
     /**
      * Returns the text of the message or of the request
      * <p>
-     * if {@link #getRequestType()} == {@link RequestType#MESSAGE} and a field 'text' is empty, than
-     * can be field 'caption' if it presents
+     * if {@link #getRequestType()} == {@link RequestType#MESSAGE} and a field 'text' is empty, than can be field
+     * 'caption' if it presents
      *
      * @return the text of the message or of the request. Return null if {@link Update} has no text
      * @see AbstractUpdateRequest#AbstractUpdateRequest(Update)
@@ -169,13 +179,19 @@ public interface UpdateRequest {
      * Returns the response that should be sent to Telegram
      *
      * @return the response, or null if no one {@link UpdateHandler} or
-     * {@link PreUpdateFilter}/{@link PostUpdateFilter}/{@link ConclusivePostUpdateFilter} set
-     * response
+     * {@link PreUpdateFilter}/{@link PostUpdateFilter}/{@link ConclusivePostUpdateFilter} set response
      * @see ResponseSetter
      */
     @Nullable
     TelegramResponse getResponse();
 
+    /**
+     * This field contains responses from the telegram. It may be empty if there was no response or the response to the
+     * telegram itself has not been sent yet.
+     *
+     * @return a list of telegram responses.
+     */
+    @NonNull
     List<Serializable> getResponseFromTelegram();
 
     /**

--- a/src/main/java/io/github/drednote/telegram/datasource/scenarioid/ScenarioId.java
+++ b/src/main/java/io/github/drednote/telegram/datasource/scenarioid/ScenarioId.java
@@ -2,7 +2,7 @@ package io.github.drednote.telegram.datasource.scenarioid;
 
 public interface ScenarioId {
 
-    Long getId();
+    String getId();
 
     String getScenarioId();
 

--- a/src/main/java/io/github/drednote/telegram/datasource/scenarioid/ScenarioIdRepository.java
+++ b/src/main/java/io/github/drednote/telegram/datasource/scenarioid/ScenarioIdRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
-public interface ScenarioIdRepository<T extends ScenarioId> extends CrudRepository<T, Long> {
+public interface ScenarioIdRepository<T extends ScenarioId> extends CrudRepository<T, String> {
 }

--- a/src/main/java/io/github/drednote/telegram/datasource/scenarioid/ScenarioIdRepositoryAdapter.java
+++ b/src/main/java/io/github/drednote/telegram/datasource/scenarioid/ScenarioIdRepositoryAdapter.java
@@ -16,7 +16,7 @@ public interface ScenarioIdRepositoryAdapter extends DataSourceAdapter {
      * @param id the numeric identifier of the scenario ID to find
      * @return an Optional containing the found ScenarioId, or empty if not found
      */
-    Optional<? extends ScenarioId> findById(Long id);
+    Optional<? extends ScenarioId> findById(String id);
 
     /**
      * Saves the specified scenario ID with userID.
@@ -24,5 +24,5 @@ public interface ScenarioIdRepositoryAdapter extends DataSourceAdapter {
      * @param scenarioId the scenario ID to be saved
      * @param id the numeric identifier associated with the scenario ID
      */
-    void save(String scenarioId, Long id);
+    void save(String scenarioId, String id);
 }

--- a/src/main/java/io/github/drednote/telegram/datasource/scenarioid/jpa/JpaScenarioIdRepositoryAdapter.java
+++ b/src/main/java/io/github/drednote/telegram/datasource/scenarioid/jpa/JpaScenarioIdRepositoryAdapter.java
@@ -11,12 +11,12 @@ public class JpaScenarioIdRepositoryAdapter implements ScenarioIdRepositoryAdapt
     private final JpaScenarioIdRepository scenarioIdRepository;
 
     @Override
-    public Optional<? extends ScenarioId> findById(Long id) {
+    public Optional<? extends ScenarioId> findById(String id) {
         return scenarioIdRepository.findById(id);
     }
 
     @Override
-    public void save(String scenarioId, Long id) {
+    public void save(String scenarioId, String id) {
         ScenarioIdEntity entity = new ScenarioIdEntity();
         entity.setId(id);
         entity.setScenarioId(scenarioId);

--- a/src/main/java/io/github/drednote/telegram/datasource/scenarioid/jpa/ScenarioIdEntity.java
+++ b/src/main/java/io/github/drednote/telegram/datasource/scenarioid/jpa/ScenarioIdEntity.java
@@ -26,8 +26,7 @@ public class ScenarioIdEntity implements ScenarioId {
 
     @Id
     @Column(name = "id", nullable = false)
-    @JdbcTypeCode(SqlTypes.BIGINT)
-    private Long id;
+    private String id;
     @Column(name = "scenario_id", nullable = false)
     private String scenarioId;
 

--- a/src/main/java/io/github/drednote/telegram/filter/PermissionProperties.java
+++ b/src/main/java/io/github/drednote/telegram/filter/PermissionProperties.java
@@ -21,55 +21,52 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 public class PermissionProperties {
 
-  /**
-   * The default role assigned to users with no roles.
-   */
-  public static final String DEFAULT_ROLE = "NONE";
-
-  /**
-   * Define who has access to bot
-   */
-  private Access access = Access.ALL;
-  /**
-   * If a user has no role, this role will be set by default
-   */
-  private String defaultRole = DEFAULT_ROLE;
-  /**
-   * The list of roles with privileges
-   */
-  private Map<String, Role> roles = Map.of();
-  /**
-   * The map of [userId:role]
-   *
-   * @deprecated should be removed. Not safety for production
-   */
-  @Deprecated(forRemoval = true)
-  private Map<Long, Set<String>> assignRole = Map.of();
-
-  /**
-   * Enumeration of access control modes.
-   */
-  public enum Access {
     /**
-     * All users have access to bot
+     * The default role assigned to users with no roles.
      */
-    ALL,
-    /**
-     * Only users with specific privilege have access to bot
-     */
-    BY_ROLE
-  }
-
-  /**
-   * Defines the privileges and attributes of a role
-   */
-  @Getter
-  @Setter
-  public static class Role {
+    public static final String DEFAULT_ROLE = "NONE";
 
     /**
-     * Indicates whether the role has read privileges
+     * Define who has access to bot
      */
-    private boolean canRead;
-  }
+    private Access access = Access.ALL;
+    /**
+     * If a user has no role, this role will be set by default
+     */
+    private String defaultRole = DEFAULT_ROLE;
+    /**
+     * The list of roles with privileges
+     */
+    private Map<String, Role> roles = Map.of();
+    /**
+     * The map of [userId:role]
+     */
+    private Map<Long, Set<String>> assignRole = Map.of();
+
+    /**
+     * Enumeration of access control modes.
+     */
+    public enum Access {
+        /**
+         * All users have access to bot
+         */
+        ALL,
+        /**
+         * Only users with specific privilege have access to bot
+         */
+        BY_ROLE
+    }
+
+    /**
+     * Defines the privileges and attributes of a role
+     */
+    @Getter
+    @Setter
+    public static class Role {
+
+        /**
+         * Indicates whether the role has read privileges
+         */
+        private boolean canRead;
+    }
 }

--- a/src/main/java/io/github/drednote/telegram/filter/post/ScenarioIdPersistFilter.java
+++ b/src/main/java/io/github/drednote/telegram/filter/post/ScenarioIdPersistFilter.java
@@ -4,13 +4,14 @@ import io.github.drednote.telegram.core.request.UpdateRequest;
 import io.github.drednote.telegram.filter.FilterOrder;
 import io.github.drednote.telegram.handler.scenario.Scenario;
 import io.github.drednote.telegram.handler.scenario.ScenarioAccessor;
+import io.github.drednote.telegram.handler.scenario.ScenarioIdResolver;
 import io.github.drednote.telegram.handler.scenario.configurer.transition.ScenarioResponseMessageTransitionConfigurer;
 import java.io.Serializable;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
-import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.message.MaybeInaccessibleMessage;
 
 /**
  * {@code ScenarioIdPersistFilter} is a filter that persists the scenario associated with
@@ -44,8 +45,8 @@ public class ScenarioIdPersistFilter implements ConclusivePostUpdateFilter {
                         + "for scenario state is enabled. Scenario Id = '{}'", scenario.getId());
                 }
                 for (Serializable response : responses) {
-                    if (response instanceof Message message) {
-                        String messageId = message.getMessageId().toString();
+                    if (response instanceof MaybeInaccessibleMessage message) {
+                        String messageId = ScenarioIdResolver.resolveId(request, message);
                         scenario.getAccessor().setId(messageId);
                         break;
                     }

--- a/src/main/java/io/github/drednote/telegram/filter/pre/RoleFilter.java
+++ b/src/main/java/io/github/drednote/telegram/filter/pre/RoleFilter.java
@@ -1,7 +1,5 @@
 package io.github.drednote.telegram.filter.pre;
 
-import static io.github.drednote.telegram.filter.FilterOrder.DEFAULT_PRECEDENCE;
-
 import io.github.drednote.telegram.core.request.UpdateRequest;
 import io.github.drednote.telegram.datasource.permission.Permission;
 import io.github.drednote.telegram.datasource.permission.Permission.DefaultPermission;
@@ -64,7 +62,7 @@ public class RoleFilter implements PriorityPreUpdateFilter {
    * @param request The incoming Telegram update request to be pre-filtered, not null
    */
   @Override
-  @SuppressWarnings({"java:S1874", "deprecation"})
+  @SuppressWarnings({"java:S1874"})
   public void preFilter(@NonNull UpdateRequest request) {
     Assert.notNull(request, "UpdateRequest");
 

--- a/src/main/java/io/github/drednote/telegram/handler/scenario/ScenarioIdResolver.java
+++ b/src/main/java/io/github/drednote/telegram/handler/scenario/ScenarioIdResolver.java
@@ -2,6 +2,7 @@ package io.github.drednote.telegram.handler.scenario;
 
 import io.github.drednote.telegram.core.annotation.BetaApi;
 import io.github.drednote.telegram.core.request.UpdateRequest;
+import org.telegram.telegrambots.meta.api.objects.message.MaybeInaccessibleMessage;
 
 /**
  * Interface for resolving and managing scenario IDs based on #{@link UpdateRequest}.
@@ -34,5 +35,16 @@ public interface ScenarioIdResolver {
      * @param id      the new scenario ID to be saved
      */
     void saveNewId(UpdateRequest request, String id);
+
+    /**
+     * Resolve unique id for message.
+     *
+     * @param request request
+     * @param message message
+     * @return unique id
+     */
+    static String resolveId(UpdateRequest request, MaybeInaccessibleMessage message) {
+        return request.getUserAssociatedId() + "_" + message.getMessageId().toString();
+    }
 }
 

--- a/src/test/java/io/github/drednote/telegram/core/request/AbstractUpdateRequestTest.java
+++ b/src/test/java/io/github/drednote/telegram/core/request/AbstractUpdateRequestTest.java
@@ -98,6 +98,7 @@ class AbstractUpdateRequestTest {
     }
 
     @Override
+    @NonNull
     public List<Serializable> getResponseFromTelegram() {
       return List.of();
     }


### PR DESCRIPTION
- Breaking changes:
	- ScenarioId - change type of id from Long to String
	- Scenario - change the algorithm of choosing scenario id. Already saved to BD scenarios won't be work after update.
- Changes:
	- add getUserAssociatedId method on UpdateRequest class
	- TelegramScope - add InheritableThreadLocal